### PR TITLE
feat: Update login and sign-in components with dark-themed close bar …

### DIFF
--- a/src/pages/logIn/logIn.jsx
+++ b/src/pages/logIn/logIn.jsx
@@ -36,7 +36,7 @@ const Login = () => {
   return (
     <div className="bg-gray-100 min-h-screen">
       {/* Close Bar */}
-      <div className="bg-white shadow-md">
+      <div className="bg-black text-white shadow-md">
         <div className="container mx-auto px-4 py-3 flex justify-between items-center">
           <div className="flex items-center space-x-3">
             <img src="/nikeWhite.svg" alt="Nike Logo" className="w-8 h-8" />
@@ -44,10 +44,10 @@ const Login = () => {
           </div>
           <button
             onClick={handleClose}
-            className="p-2 rounded-full hover:bg-gray-100 transition-colors"
+            className="p-2 rounded-full transition-colors"
             title="Close and go back"
           >
-            <i className="fas fa-times text-xl text-gray-600 hover:text-black"></i>
+            <i className="fas fa-times text-xl text-gray-100"></i>
           </button>
         </div>
       </div>
@@ -55,7 +55,7 @@ const Login = () => {
       {/* Login Section */}
       <section className="py-16">
         <div className="container mx-auto px-4">
-          <div className="max-w-md mx-auto bg-white rounded-lg shadow-lg overflow-hidden">
+          <div className="max-w-md mx-auto rounded-lg shadow-lg overflow-hidden">
             {/* Header */}
             <div className="bg-gradient-to-r from-black to-gray-900 text-white p-6 text-center">
               <div className="flex items-center justify-center space-x-3 mb-4">

--- a/src/pages/signIn/signIn.jsx
+++ b/src/pages/signIn/signIn.jsx
@@ -51,6 +51,7 @@ const SignIn = () => {
     <div className="bg-gray-100 min-h-screen">
       {/* Close Bar */}
       <div className="bg-white shadow-md">
+        <div className="bg-black text-white shadow-md">
         <div className="container mx-auto px-4 py-3 flex justify-between items-center">
           <div className="flex items-center space-x-3">
             <img src="/nikeWhite.svg" alt="Nike Logo" className="w-8 h-8" />
@@ -58,10 +59,10 @@ const SignIn = () => {
           </div>
           <button
             onClick={handleClose}
-            className="p-2 rounded-full hover:bg-gray-100 transition-colors"
+            className="p-2 rounded-full transition-colors"
             title="Close and go back"
           >
-            <i className="fas fa-times text-xl text-gray-600 hover:text-black"></i>
+            <i className="fas fa-times text-xl text-gray-100"></i>
           </button>
         </div>
       </div>
@@ -294,7 +295,8 @@ const SignIn = () => {
         </div>
       </section>
     </div>
+    </div>
   )
 }
 
-export default SignIn
+export default SignIn;


### PR DESCRIPTION
This pull request updates the visual styling of the close bar in both the login and sign-in pages, aligning them with a darker theme and improving consistency. It also includes a minor fix to the export statement in the sign-in page.

**Styling updates for close bar:**

* Changed the close bar background from white to black, updated text color to white, and adjusted icon colors for better visibility in both `src/pages/logIn/logIn.jsx` and `src/pages/signIn/signIn.jsx`. [[1]](diffhunk://#diff-41104cf13c6b320ccb18cb9e8842520b9587edd322307d0e37f21a9b20b2ade4L39-R58) [[2]](diffhunk://#diff-5c7ccc260da3fd2b1687db87b1d7fb249cdfefeefc944198aa7abaa0823cda38R54-R65)
* Removed the hover background color on the close button and standardized icon styling for consistency. [[1]](diffhunk://#diff-41104cf13c6b320ccb18cb9e8842520b9587edd322307d0e37f21a9b20b2ade4L39-R58) [[2]](diffhunk://#diff-5c7ccc260da3fd2b1687db87b1d7fb249cdfefeefc944198aa7abaa0823cda38R54-R65)
* Removed the white background from the login section card to better match the new theme in `src/pages/logIn/logIn.jsx`.

**Code consistency:**

* Fixed the export statement format in `src/pages/signIn/signIn.jsx` for consistency with best practices.