### PR TITLE
Refractor/logo

### DIFF
--- a/src/assets/assets.js
+++ b/src/assets/assets.js
@@ -3,7 +3,7 @@ import AirJordan from './airjordan1.avif'
 import AirForce1 from './airforce1.jpg'
 import FootballBoots from './boots.avif'
 import DriFit from './drifit.jpg'
-import DunkLowRetro from './dunkLowretro.avif'
+import DunkLowRetro from './dunklowretro.avif'
 import Vaporfly from './vaporfly.avif'
 import HaywardBackpack from './HaywardBag.webp'
 


### PR DESCRIPTION
This pull request makes a minor correction to the import statement for the `DunkLowRetro` asset in the `src/assets/assets.js` file. The filename was updated to match the correct casing.

* Fixed the import path for `DunkLowRetro` by changing `'./dunkLowretro.avif'` to `'./dunklowretro.avif'` to ensure the asset loads correctly.